### PR TITLE
Objectives of the NuCypher economic protocol 

### DIFF
--- a/mint-paper.tex
+++ b/mint-paper.tex
@@ -23,7 +23,7 @@
 The NuCypher network's primary purpose is to provide a {\it decentralized access control service} to adopters. \textit{Adopters} are a catch-all term for the developers and purveyors of various technological applications and systems, including but not limited to: consumer-facing applications (e.g. a genomic record management app), platforms (e.g. a marketplace for mobile browsing data), Web 3 infrastructure (e.g. a decentralized database-as-a-service), games (e.g. a digital collectible card game) and other multi-endpoint systems (e.g. intra-vehicle data sharing via IOT devices).
 \\
 \\
-NuCypher network nodes, hereafter referred to as \textit{workers}, are an indispensable component of this access control service. Distributed around the world, workers run NuCypher software on their machines in order to facilitate data sharing flows within adopters' applications and systems. This on-demand service involves setting access permissions associated with encrypted data payloads, by conditionally transforming associated ciphertexts. In some respects, this service can be compared to a large-scale key management system (e.g. Amazon Web Services KMS), but critically, every sharing flow is end-to-end encrypted and thus does not imply trust in the security or integrity of a centralized third-party or data custodian. 
+NuCypher network nodes, hereafter referred to as \textit{workers}, are an indispensable component of this access control service. Distributed around the world, workers run NuCypher software on their machines in order to facilitate data sharing flows within adopters' applications and systems. This involves enforcing permissions, initially chosen by data owners, that enable access to their encrypted data payloads. More specifically, workers transform ciphertexts associated with the underlying data, such that they are then decryptable by valid recipients. Data owners can also program the enforcement to be based on the fulfillment of certain conditions. In some respects, this service can be compared to a large-scale key management system (e.g. Amazon Web Services KMS), but critically, every sharing flow is end-to-end encrypted and thus does not imply trust in the security or integrity of a centralized third-party or data custodian. 
 \\
 \\
 Workers have three main duties:
@@ -32,7 +32,7 @@ Workers have three main duties:
    \item Securely holding onto sharing policies (objects providing the rules and parameters for access to data) and their corresponding {\it re-encryption key fragments}
    \item Performing {\it re-encryptions} (enforcing a permission) in response to legitimate access requests
 \end{enumerate}
-Workers are compensated for these efforts through \textit{fees} (denominated in ETH), paid for by adopters. These costs can optionally be passed on to the end-users of adopting applications. As of April 2019, sharing policies are priced exclusively based on their duration. In practice, this means the cost to an adopter for a given permission update depends on the number of data recipients and for how long they need access. However, in forthcoming versions, the number of access requests associated with a sharing policy may also influence the sum charged. The details of current and future payment models are covered in later sections.
+Workers are compensated for these efforts through \textit{fees} (denominated in ETH), paid for by adopters. These costs can optionally be passed on to the end-users of adopting applications. As of April 2019, sharing policies are priced exclusively based on their duration, and one policy is required for each designated recipient (one policy per public key). In practice, this means the cost to an adopter for a given sharing flow depends on the number of recipients and for how long they need access. However, in forthcoming versions, the number of access requests associated with a sharing policy may also influence the sum charged, and a single policy may grant access to multiple recipients. The details of current and future payment models are covered in later sections.
 
 Because some adopters will require sharing policies that last for extended periods (e.g. for over 6 months), it is critical that worker availability is highly predictable. In other words, workers should not be assigned an access management job if they haven't committed to work for at least the duration of the associated sharing policy. 
 \\
@@ -48,7 +48,7 @@ Workers need not be trusted with the underlying private data, given that the obj
 
 \section{Objectives of the Economic Protocol}
 
-Though the economic protocol is a means to prevent or minimize worker misbehavior introduced in Section \ref{context}, this alone is a risky oversimplification. Economic design choices have a far broader impact, and affect everything from the network's market capitalization to the geographical distribution of workers.
+Though the economic protocol is a means to prevent or minimize worker misbehavior introduced in Section \ref{context}, this alone is an oversimplification. Economic design choices have a far broader impact, and affect everything from the network's market capitalization to the geographical distribution of workers.
 \\
 Hence, all economic mechanisms and strategies (already implemented, or to be implemented) should address one or more high-level network objectives. Note that some objectives align, clash or are \textit{sub-goals} of one another; nonetheless, each is evaluated individually here.
 \\
@@ -58,8 +58,8 @@ Hence, all economic mechanisms and strategies (already implemented, or to be imp
    Increasing, retaining and diversifying a pool of adopters is the NuCypher network's highest priority. This objective can be broken into the following endeavors: 
    \begin{enumerate}
    \item Maximizing the quality of service. This sustains the network via retention of satisfied adopters and grows the pool via their recommendations. Service quality can be understood in terms of reliability, security, friction (lack of) and cost-effectiveness, which are explored as distinct objectives later in this section. 
-   \item Maximizing the network's exposure to non-adopters. For the adopter pool to grow, developers of relevant applications must be aware of the service. A historically popular means of bootstrapping marketing efforts has involved leveraging the network effects of speculation on a freely tradeable native token, where the presence of a liquid asset on exchanges, in media, and on forums/other channels provides free exposure to purportedly relevant audiences. However, prominence of this kind is skewed towards native tokens with the largest market capitalizations, since they are the most liquid and boast the most interested parties. A token with a realistic market cap may be more fundamentally sustainable, but may not garner the same notoriety. 
-   \item Maximize the service's competitive edge. Given that the entirety of NuCypher technology (cryptography, system architecture, code, etc.) is necessarily open source, the barrier impeding a competitor from product replication is fairly small. A competitive advantage, as perceived by adopters or would-be adopters, is the superior quality of service relative to that of similar or copycat projects. Whether a competitive advantage, such as greater reliability, is realized and maintained, is determined in part by the aggregate decision-making of the network's workers. Moreover, while code can be cloned, competent workers are a finite resource. Operating nodes in multiple networks is possible, but capital and hardware constraints limit this. By way of illustration, imagine if a large swathe of workers decided to abandon the NuCypher network in unison. This would harm the perceived and actual reliability of the service, and potentially boost a competing network via a migration of new service-providers. Conversely, if a large swathe of workers decided to formally commit their efforts to the network for an extended time period, this solidifies the service's perceived and actual reliability, and makes it more difficult for another network to attract those workers (since they now have capital locked up in the NuCypher network). These collective decisions are strongly influenced by the network's economic design. 
+   \item Maximizing the network's exposure to non-adopters. For the adopter pool to grow, developers of relevant applications must be aware of the service. A historically popular means of bootstrapping marketing efforts has involved leveraging the network effects of speculation on a freely tradeable native token, where the presence of a liquid asset on exchanges, in media, and on forums/other channels provides free exposure to purportedly relevant audiences. However, prominence of this kind is arguably skewed towards networks with the largest market capitalizations, since they are the most liquid, boast the most interested parties and get disproportionate media coverage as a result. A token with a realistic market cap may be more financially and reputationally sustainable, but may not garner the same notoriety. It's worth noting that for some projects, a large market cap and associated name-recognition has not translated into high-quality adoption, and in some cases ostensible over-valuation has dissuaded developers from building in their ecosystem.
+   \item Maximize the service's competitive edge. Given that the entirety of NuCypher technology (cryptography, system architecture, code, etc.) is necessarily open source, the barrier impeding a competitor from product replication is rather feeble. A competitive advantage, as perceived by adopters or would-be adopters, is the superior quality of service relative to that of similar or copycat projects. Whether a competitive advantage, such as greater reliability, is realized and maintained, is determined in part by the aggregate decision-making of the network's workers. Moreover, while code can be cloned, competent workers are a finite resource. Operating nodes in multiple networks is possible, but capital and hardware constraints limit this. By way of illustration, imagine if a large swathe of workers decided to abandon the NuCypher network in unison. This would harm the perceived and actual reliability of the service, and potentially boost a competing network via a migration of new service-providers. Conversely, if a large swathe of workers decided to formally commit their efforts to the network for an extended time period, this solidifies the service's perceived and actual reliability, and makes it more difficult for another network to attract those workers (since they now have capital locked up in the NuCypher network). These collective decisions are strongly influenced by the network's economic design. 
    \end{enumerate}
    In summary, the network must aspire towards an inimitable reputation, flexible capacity and recognized stability. These attributes are partially a function of worker decisions (and the alignment of their self-interest with the network's health), the populating and maintenance of whom requires a sensible economic protocol. 
    \\
@@ -79,11 +79,11 @@ Hence, all economic mechanisms and strategies (already implemented, or to be imp
    \\
    \item \textbf{Ensure a low-friction and cost-effective service}\label{friction}
    \\
-   This objective refers to the practicality of integrating the network's service into an adopter's application. The manner in  which an adopter pays workers is highly relevant here, including the currency in which fees are paid, and the aspects of the service that are chargeable. Zooming out, there is also a natural tension between the affordability of the service to adopters and the affordability/desirability to provide the service as a worker. The exact fee model has huge consequences for the revenue workers can earn from fees (objective \ref{profit}), which turn impacts the parameterization of mechanisms for worker non-fee compensation, such as rewards. Fee models are explored in greater detail in objective \ref{profit}.
+   This objective refers to the practicality of integrating the network's service into an adopter's application. The manner in which an adopter pays workers is highly relevant here, including the currency in which fees are paid, and the aspects of the service that are chargeable. Zooming out, there is also a natural tension between the affordability of the service to adopters and the affordability/desirability to provide the service as a worker. The exact fee model has huge consequences for the revenue workers can earn from fees (objective \ref{profit}), which turn impacts the parameterization of mechanisms for worker non-fee compensation, such as rewards. Fee models are explored in greater detail in objective \ref{profit}.
    \\
    \item \textbf{Ensure predictable and healthy worker participation/commitment}\label{part}
    \\
-   A \textit{participating worker} can be defined as one who has committed some minimum sum of capital (denominated in the native token) to the network for some non-trivial period of time (e.g. 1 month). In other words, a service-provider with a locked security deposit. Overall participation can then be measured in absolute terms, by the total value of committed capital to the network by workers, or in relative terms, by the percentage of the total network capitalization that is committed at a given moment. With regard to the latter, it is unclear what percentage constitutes a \textit{healthy} participation rate. There is a positive relationship between participation and objectives \ref{reliable} and \ref{secure}, but overly high participation rates may clash with objective \ref{liquid}, because committed capital is by definition non-liquid. High participation rates can also dilute worker income, as explored in objective \ref{profit}.
+   A \textit{participating worker} can be defined as one who has committed some minimum sum of capital (denominated in the native token) to the network for some non-trivial period of time (e.g. 1 month). In other words, a service-provider with a locked security deposit. Overall participation can then be measured in absolute terms, by the total value of committed capital to the network by workers, or in relative terms, by the percentage of the total network capitalization that is committed at a given moment. With regard to the latter, it is unclear what percentage constitutes a \textit{healthy} participation rate. There is a positive relationship between participation and objectives \ref{reliable} and \ref{secure}, but overly high participation rates may clash with objective \ref{liquid}, because committed capital is by definition non-liquid. This in turn impacts objective \ref{decent}, where a lack of freely traded tokens can mean that the total number of independent workers does not grow sufficiently to maintain or increase the network's decentralization. High participation rates also dilute worker income, as explored in objective \ref{profit}.z`
    \\
    \\
    For a given worker in a given moment, their decisions to participate and for how long, will (at the very least) be influenced by :
@@ -162,33 +162,13 @@ To incentivize predictable behavior, and disincentize misbehavior, in particular
 \\
 Stakes represent an initial deposit of non-trivial value, and will increase in value if rewards are {\it re-staked} by the worker over time. Access control jobs are assigned proportionally to the size of a worker's stake, relative to the aggregate of all current stakes in the network. Similarly, a worker's reward payout depends on the relative size of their stake, with coefficients based on other factors such as the length of their committed service to the network. 
 
-\section{Threats to the Network}
-
 \section{Evaluation of Existing and Historical Economic Protocols}
 
-
-
-
-
 %\subsection{}
-
 
 \appendix
 
 % The slashing protocol
 \input{slashing-proto.tex}
 
-\end{document}  
-
-
-   \begin{enumerate}
-   \item \textit{Approaches}
-   \item \textit{Issues}
-   \item \textit{Synergies \& Sub-Goals}
-   \begin{enumerate}
-   \item{Ensure appropriate token liquidity}
-   \item{Ensure secure service}
-   \item{Ensure reliable service}
-   \end{enumerate}
-   \item \textit{Trade-offs}
-   \end{enumerate}
+\end{document}


### PR DESCRIPTION
Though an economic protocol is a means to prevent or minimize worker/staker misbehavior, this alone is an oversimplification. Economic design choices have a far broader impact on the network, affecting everything from the market capitalization to the geographical distribution of workers.
Hence, all economic mechanisms, parameters and strategies (whether already implemented, or to be implemented) should address one or more high-level network objectives. Some objectives align, clash or are sub-goals of one another; nonetheless, the importance of each is evaluated individually. 

These objectives are a first draft and are subject to change based on team feedback/criticism. I consider it a fairly urgent task to contextualize mechanisms like _slashing_ or a _Worklock_ against a prioritized list of the project's ambitions.